### PR TITLE
Add registration form

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Shield, Eye, EyeOff } from "lucide-react"
+
+export default function RegisterPage() {
+  const router = useRouter()
+  const [showPassword, setShowPassword] = useState(false)
+  const [formData, setFormData] = useState({
+    name: "",
+    email: "",
+    password: "",
+    department: "",
+    position: "",
+    phone: "",
+    location: "",
+  })
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target
+    setFormData((prev) => ({ ...prev, [id]: value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    try {
+      const res = await fetch("/api/auth/register", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+      })
+
+      if (!res.ok) {
+        const error = await res.json()
+        throw new Error(error.message || "Erro ao registrar")
+      }
+
+      const data = await res.json()
+      if (data.token) {
+        if (typeof window !== "undefined") {
+          localStorage.setItem("token", data.token)
+        }
+        router.push("/dashboard")
+      }
+    } catch (error) {
+      console.error("Erro ao registrar:", error)
+      if (typeof window !== "undefined") {
+        alert("Falha no cadastro: " + (error as Error).message)
+      }
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100">
+            <Shield className="h-6 w-6 text-blue-600" />
+          </div>
+          <CardTitle className="text-2xl font-bold">Criar Conta</CardTitle>
+          <CardDescription>Preencha os dados para se registrar</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">Nome</Label>
+              <Input id="name" value={formData.name} onChange={handleChange} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">E-mail</Label>
+              <Input id="email" type="email" value={formData.email} onChange={handleChange} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Senha</Label>
+              <div className="relative">
+                <Input id="password" type={showPassword ? "text" : "password"} value={formData.password} onChange={handleChange} required />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                  onClick={() => setShowPassword(!showPassword)}
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </Button>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="department">Departamento</Label>
+              <Input id="department" value={formData.department} onChange={handleChange} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="position">Cargo</Label>
+              <Input id="position" value={formData.position} onChange={handleChange} required />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="phone">Telefone</Label>
+              <Input id="phone" value={formData.phone} onChange={handleChange} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="location">Localização</Label>
+              <Input id="location" value={formData.location} onChange={handleChange} />
+            </div>
+            <Button type="submit" className="w-full">Cadastrar</Button>
+          </form>
+          <div className="mt-4 text-center text-sm">
+            <Link href="/login" className="text-blue-600 hover:underline">
+              Já tem conta? Entrar
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add registration page with full form
- send POST request to `/api/auth/register`
- store returned token and redirect to dashboard on success

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862817c63148329a157195dc312cf0e