### PR TITLE
Update README for local Postgres via Prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ FRONTEND_URL=http://localhost:3000
 MONGODB_URI=mongodb://localhost:27017/digital-signature
 
 # Prisma database connection string
-DATABASE_URL=mongodb://localhost:27017/digital-signature
+# Example for a local PostgreSQL instance
+DATABASE_URL=postgresql://localhost:5432/digital-signature
 
 # Secret key for JWT tokens
 JWT_SECRET=your_jwt_secret

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Signature Application
 
-This project contains a Next.js frontend and an Express backend for a digital signature application.
+This project contains a Next.js frontend and an Express backend for a digital signature application. The database runs locally and is accessed via Prisma using PostgreSQL.
 
 ## Prerequisites
 
 - **Node.js 18** or newer with **npm**.
-- A local or remote **MongoDB** server accessible to the application.
+- A local **MongoDB** server accessible to the application.
+- A local **PostgreSQL** server used by Prisma to manage the database connection.
 
 ## Installation
 
@@ -32,8 +33,10 @@ cp .env.example .env
 ```
 
 The available variables are documented in `.env.example`.
-Prisma uses `DATABASE_URL` to connect to your MongoDB instance. You can reuse the
-same value as `MONGODB_URI`.
+Prisma uses `DATABASE_URL` to connect to the local PostgreSQL instance. The default
+value (`postgresql://localhost:5432/digital-signature`) should point to your local Postgres database.
+
+All database operations performed through Prisma run against this local PostgreSQL instance.
 
 ## Seeding the database
 
@@ -43,13 +46,13 @@ After configuring the environment variables, you can populate the database with 
 node scripts/seed.js
 ```
 
-If you prefer using Prisma to inspect the database, run:
+If you prefer using Prisma to inspect the Postgres database, run:
 
 ```bash
 npx prisma studio
 ```
 
-This connects to the database defined by `MONGODB_URI` and inserts example users and reports.
+This opens Prisma Studio connected via `DATABASE_URL` to your local Postgres database.
 
 ## Running the application
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,12 +3,12 @@ generator client {
 }
 
 datasource db {
-  provider = "mongodb"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
 }
 
 model User {
-  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  id        String   @id @default(uuid())
   name      String
   email     String   @unique
   password  String
@@ -17,15 +17,15 @@ model User {
   position  String?
   phone     String?
   location  String?
-  reports   Report[] @relation(fields: [id], references: [author])
+  reports   Report[]
 }
 
 model Report {
-  id          String   @id @default(auto()) @map("_id") @db.ObjectId
+  id          String   @id @default(uuid())
   title       String
   description String?
   content     String?
-  author      String   @db.ObjectId
+  author      String
   department  String?
   type        String?
   status      String?
@@ -33,7 +33,7 @@ model Report {
 }
 
 model Signature {
-  id              String   @id @default(auto()) @map("_id") @db.ObjectId
+  id              String   @id @default(uuid())
   documentTitle   String
   signer          String
   signerEmail     String


### PR DESCRIPTION
## Summary
- document use of a local PostgreSQL database through Prisma
- adjust `.env.example` and Prisma schema for Postgres

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_6862ee6285588329802a4162e0cd65f4